### PR TITLE
Get the accounts under an ou  in an organization

### DIFF
--- a/.github/workflows/configure-dynatrace.yaml
+++ b/.github/workflows/configure-dynatrace.yaml
@@ -1,0 +1,30 @@
+name: Create and configure Dynatrace connections
+# on a schedule or manually
+# Connect to CT organizations and get all the AWS accounts of interest
+# Get the managed services they use
+# Create or update Dynatrace Connections.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  configure_dynatrace:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip' # caching pip dependencies
+      - run: pip install -r python/requirements.txt
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.CT_ORG_READ_ONLY_ROLE_ARN }}
+          aws-region: eu-west-2
+      # Will for now just query Organizations. Looking for no failure.
+      # Not printing anything out as it will have account information.
+      - run: |
+          cd python
+          python dynatrace.py --account-numbers 851012735550

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ test-activegate
 
 # ide
 .vscode
+
+# python
+__pycache__
+.coverage

--- a/python/.coveragerc
+++ b/python/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+branch = True
+source = ../python
+omit =
+        ./tests/**
+        *__init__*
+        ~/.pyenv/versions/**
+[report]
+exclude_lines = 
+        pragma: no cover
+        if __name__ == .__main__.:

--- a/python/dynatrace.py
+++ b/python/dynatrace.py
@@ -1,5 +1,5 @@
 import argparse
-from lib import control_tower_util, client
+from lib import control_tower_util, client, dynatrace_util
 
 parser = argparse.ArgumentParser()
 
@@ -14,8 +14,10 @@ if __name__ == '__main__':
    
    client = client.Client()
    ct = control_tower_util.ControlTowerUtil(client=client)
-   ct.list_all_accounts_for_ou_under_root(
+   organization_accounts = ct.list_all_accounts_for_ou_under_root(
       ou_name=vars(args)["ou_name"],
       account_numbers=vars(args)["account_numbers"],
       apply_to_all=vars(args)["apply_to_all"]
    )
+   
+   dt = dynatrace_util.DynatraceUtil(organization_accounts=organization_accounts)

--- a/python/dynatrace.py
+++ b/python/dynatrace.py
@@ -7,6 +7,11 @@ parser.add_argument('--ou-name', required=False, default='Workloads', help='The 
 parser.add_argument('--account-numbers', required=False, help='A specific lists of account numbers to Create Dynatrace connections for.')
 parser.add_argument('--apply-to-all', required=False, default=False, help='Create Dynatrace connections for all accounts under the specified OU. \
    This is a catch all to confirm you have made the choice to apply to all')
+parser.add_argument('--dynatrace-prod-token', required=True, help='The token to use to authenticate against the dynatrace prod environemnt.')
+parser.add_argument('--dynatrace-non-prod-token', required=True, help='The token to use to authenticate against the dynatrace non prod environemnt.')
+parser.add_argument('--dynatrace-prod-environment', required=True, help='The name dynatrace prod environemnt, it is in the URL of the dashboard.')
+parser.add_argument('--dynatrace-non-prod-environment', required=True, help='The name dynatrace non prod environemnt, it is in the URL of the dashboard.')
+parser.add_argument('--dynatrace-iam-role', required=False, default='CTOrgReadonly', help='The IAM role that has permission to read organisation information.')
 
 args = parser.parse_args()
 
@@ -20,4 +25,12 @@ if __name__ == '__main__':
       apply_to_all=vars(args)["apply_to_all"]
    )
    
-   dt = dynatrace_util.DynatraceUtil(organization_accounts=organization_accounts)
+   dt = dynatrace_util.DynatraceUtil(
+      organization_accounts=organization_accounts,
+      prod_env_name=vars(args)["dynatrace_prod_environment"],
+      prod_token=vars(args)["dynatrace_prod_token"],
+      non_prod_env_name=vars(args)["dynatrace_non_prod_environment"],
+      non_prod_token=vars(args)["dynatrace_non_prod_token"],
+      dynatrace_iam_role=vars(args)["dynatrace_iam_role"])
+   
+   dt.configure_connections()

--- a/python/dynatrace.py
+++ b/python/dynatrace.py
@@ -19,4 +19,3 @@ if __name__ == '__main__':
       account_numbers=vars(args)["account_numbers"],
       apply_to_all=vars(args)["apply_to_all"]
    )
-   print(ct.accounts)

--- a/python/dynatrace.py
+++ b/python/dynatrace.py
@@ -1,0 +1,22 @@
+import argparse
+from lib import control_tower_util, client
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument('--ou-name', required=False, default='Workloads', help='The OU below root where accounts exist.')
+parser.add_argument('--account-numbers', required=False, help='A specific lists of account numbers to Create Dynatrace connections for.')
+parser.add_argument('--apply-to-all', required=False, default=False, help='Create Dynatrace connections for all accounts under the specified OU. \
+   This is a catch all to confirm you have made the choice to apply to all')
+
+args = parser.parse_args()
+
+if __name__ == '__main__':
+   
+   client = client.Client()
+   ct = control_tower_util.ControlTowerUtil(client=client)
+   ct.list_all_accounts_for_ou_under_root(
+      ou_name=vars(args)["ou_name"],
+      account_numbers=vars(args)["account_numbers"],
+      apply_to_all=vars(args)["apply_to_all"]
+   )
+   print(ct.accounts)

--- a/python/lib/__init__.py
+++ b/python/lib/__init__.py
@@ -1,2 +1,3 @@
 from .control_tower_util import *
 from .client import *
+from .dynatrace_util import *

--- a/python/lib/__init__.py
+++ b/python/lib/__init__.py
@@ -1,0 +1,2 @@
+from .control_tower_util import *
+from .client import *

--- a/python/lib/client.py
+++ b/python/lib/client.py
@@ -1,0 +1,25 @@
+import boto3
+
+class Client():
+   
+   def __init__(self):
+       """
+       Implementation of a Multiton pattern for the boto3 client to allow for easier testing.
+       """
+       self.clients = {}
+    
+   def client(self, service: str):
+       """
+       Add a client it if is not already registered. If the signiture is found then return the instance of the client.
+
+       :param service: The AWS service to use.
+       :type service: str.
+       :return: A boto3 client which is part of the default session.
+       """
+       service = service
+       if service not in self.clients.keys():
+           new_client = boto3.client(service)
+           self.clients[service] = new_client
+              
+       return self.clients[service]
+    

--- a/python/lib/client.py
+++ b/python/lib/client.py
@@ -2,7 +2,7 @@ import boto3
 
 class Client():
    
-   def __init__(self):
+   def __init__(self) -> None:
        """
        Implementation of a Multiton pattern for the boto3 client to allow for easier testing.
        """

--- a/python/lib/control_tower_util.py
+++ b/python/lib/control_tower_util.py
@@ -1,0 +1,124 @@
+from lib.client import Client
+
+class ControlTowerUtil():
+    
+    def __init__(self, client: Client):
+        """
+        Class for interacting with control tower.
+
+        :param client: AWS Client from the Multiton. 
+        :type client: Client.
+        """
+        
+        self.org = client.client('organizations')
+        self.accounts = []
+        self.limit_to_account_numbers = None
+        
+    def set_limit_to_account_numbers(self, account_numbers: str):
+        """
+        Set the limit_to_account_numbers.
+
+        :param account_numbers: The account numbers to set limit_to_account_numbers to 
+        :type account_numbers: str
+        """
+        
+        if account_numbers is not None:
+            account_numbers_list = account_numbers.split(',')
+            if self.limit_to_account_numbers is None:
+                self.limit_to_account_numbers = []
+            
+            self.limit_to_account_numbers = self.limit_to_account_numbers + account_numbers_list
+        
+    def append_accounts(self, accounts: list):
+        """
+        Append accounts onto the class level list of accounts for iteration over later.
+
+        :param accounts: The list of accounts to be added to the class level accounts list.
+        :type accounts: list of dict.
+        """
+        
+        if self.limit_to_account_numbers is not None:
+            for account in accounts:
+                if account['Id'] in self.limit_to_account_numbers:
+                    self.accounts.append(account)
+        else:
+            self.accounts =  self.accounts + accounts
+    
+    def list_all_accounts_for_ou_under_root(self, ou_name: str, account_numbers: str, apply_to_all: bool):
+        """
+        List all of the accounts for a specified OU that exists under the organization root. 
+
+        :param ou_name: The name of the OU to fetch the accounts for.
+        :type ou_name: str.
+        :param account_numbers: A comma seperated string of the  account numbers to create connections for.
+        :type account_numbers: str.
+        :param apply_to_all: Create Dynatrace connections for all accounts under OU.
+        :type apply_to_all: bool.
+        """
+        
+        if account_numbers is not None and apply_to_all:
+            print('If you provide a list of account numbers then apply to all must be false.')
+            exit(1)
+        
+        if account_numbers is None and not apply_to_all:
+            print('If you dont provide a list of account numbers then apply to all must be True, be certain you want to do this')
+            exit(1)
+        
+        self.set_limit_to_account_numbers(account_numbers)
+        
+        roots = self.org.list_roots()
+        root_id = roots['Roots'][0]['Id']    
+        
+        response = self.org.list_organizational_units_for_parent(ParentId=root_id, MaxResults=20)
+        self.iterate_ou_under_root(response=response, ou_name=ou_name)
+                
+        while 'NextToken' in response.keys():
+            response = self.org.list_organizational_units_for_parent(ParentId=root_id, MaxResults=20, NextToken=response['NextToken'])
+            self.iterate_ou_under_root(response=response, ou_name=ou_name)
+    
+    def iterate_ou_under_root(self, response: dict, ou_name: str):
+        """
+        Iterate over the OUs the exist under the organization if the named OU is found get the accounts that exist underneath it.
+
+        :param response: The response from the organization units for parenets command.
+        :type response: dict
+        :param ou_name: The name of the OU to get accounts for.
+        :type ou_name: str.
+        """
+        ous_under_root = response['OrganizationalUnits']
+        for ou in ous_under_root:
+            if ou['Name'] == ou_name:
+                self.list_accounts_under_ou(parent_id=ou['Id'])
+                break
+        
+    def list_accounts_under_ou(self, parent_id: str):
+        """List the accounts under an OU.
+
+        :param parent_id: The Id of the parernt OU.
+        :type parent_id: str.
+        """
+        ou_response = self.org.list_organizational_units_for_parent(ParentId=parent_id, MaxResults=20)
+        self.iterate_child_ous(ou_response=ou_response)
+        
+        while 'NextToken' in ou_response.keys():
+            ou_response = self.org.list_organizational_units_for_parent(ParentId=parent_id, MaxResults=20,NextToken=ou_response['NextToken'])
+            self.iterate_child_ous(ou_response=ou_response)
+            
+        accounts_response = self.org.list_accounts_for_parent(ParentId=parent_id, MaxResults=20)
+        self.append_accounts(accounts=accounts_response['Accounts'])
+        
+        while 'NextToken' in accounts_response.keys():
+            accounts_response = self.org.list_accounts_for_parent(ParentId=parent_id, MaxResults=20, NextToken=accounts_response['NextToken'])
+            self.append_accounts(accounts=accounts_response['Accounts'])
+        
+    def iterate_child_ous(self, ou_response: dict):
+        """Iterate the over the child OUs of an OU.
+
+        :param ou_response: The response from the organization units for parenets command.
+        :type ou_response: dict
+        """
+        
+        child_ous = ou_response['OrganizationalUnits']
+        if len(child_ous) > 0:
+            for child_ou in child_ous:
+                self.list_accounts_under_ou(parent_id=child_ou['Id'])

--- a/python/lib/control_tower_util.py
+++ b/python/lib/control_tower_util.py
@@ -75,6 +75,8 @@ class ControlTowerUtil():
         while 'NextToken' in response.keys():
             response = self.org.list_organizational_units_for_parent(ParentId=root_id, MaxResults=20, NextToken=response['NextToken'])
             self.iterate_ou_under_root(response=response, ou_name=ou_name)
+            
+        return self.accounts
     
     def iterate_ou_under_root(self, response: dict, ou_name: str):
         """

--- a/python/lib/control_tower_util.py
+++ b/python/lib/control_tower_util.py
@@ -2,7 +2,7 @@ from lib.client import Client
 
 class ControlTowerUtil():
     
-    def __init__(self, client: Client):
+    def __init__(self, client: Client) -> None:
         """
         Class for interacting with control tower.
 
@@ -14,7 +14,7 @@ class ControlTowerUtil():
         self.accounts = []
         self.limit_to_account_numbers = None
         
-    def set_limit_to_account_numbers(self, account_numbers: str):
+    def set_limit_to_account_numbers(self, account_numbers: str) -> None:
         """
         Set the limit_to_account_numbers.
 
@@ -29,7 +29,7 @@ class ControlTowerUtil():
             
             self.limit_to_account_numbers = self.limit_to_account_numbers + account_numbers_list
         
-    def append_accounts(self, accounts: list):
+    def append_accounts(self, accounts: list) -> None:
         """
         Append accounts onto the class level list of accounts for iteration over later.
 
@@ -44,7 +44,7 @@ class ControlTowerUtil():
         else:
             self.accounts =  self.accounts + accounts
     
-    def list_all_accounts_for_ou_under_root(self, ou_name: str, account_numbers: str, apply_to_all: bool):
+    def list_all_accounts_for_ou_under_root(self, ou_name: str, account_numbers: str, apply_to_all: bool) -> list:
         """
         List all of the accounts for a specified OU that exists under the organization root. 
 
@@ -54,6 +54,7 @@ class ControlTowerUtil():
         :type account_numbers: str.
         :param apply_to_all: Create Dynatrace connections for all accounts under OU.
         :type apply_to_all: bool.
+        :return: List of dicts that represent AWS accounts as under the provided OU.
         """
         
         if account_numbers is not None and apply_to_all:
@@ -78,7 +79,7 @@ class ControlTowerUtil():
             
         return self.accounts
     
-    def iterate_ou_under_root(self, response: dict, ou_name: str):
+    def iterate_ou_under_root(self, response: dict, ou_name: str) -> None:
         """
         Iterate over the OUs the exist under the organization if the named OU is found get the accounts that exist underneath it.
 
@@ -93,7 +94,7 @@ class ControlTowerUtil():
                 self.list_accounts_under_ou(parent_id=ou['Id'])
                 break
         
-    def list_accounts_under_ou(self, parent_id: str):
+    def list_accounts_under_ou(self, parent_id: str) -> None:
         """List the accounts under an OU.
 
         :param parent_id: The Id of the parernt OU.
@@ -113,7 +114,7 @@ class ControlTowerUtil():
             accounts_response = self.org.list_accounts_for_parent(ParentId=parent_id, MaxResults=20, NextToken=accounts_response['NextToken'])
             self.append_accounts(accounts=accounts_response['Accounts'])
         
-    def iterate_child_ous(self, ou_response: dict):
+    def iterate_child_ous(self, ou_response: dict) -> None:
         """Iterate the over the child OUs of an OU.
 
         :param ou_response: The response from the organization units for parenets command.

--- a/python/lib/dynatrace_util.py
+++ b/python/lib/dynatrace_util.py
@@ -1,0 +1,4 @@
+class DynatraceUtil():
+    
+    def __init__(self, organization_accounts: list):
+        self.organization_accounts = organization_accounts

--- a/python/lib/dynatrace_util.py
+++ b/python/lib/dynatrace_util.py
@@ -7,9 +7,23 @@ class DynatraceUtil():
                  prod_token: str,
                  non_prod_env_name: str, 
                  non_prod_token: str,
-                 dynatrace_iam_role: str):
+                 dynatrace_iam_role: str) -> None:
+        """_summary_
+
+        :param organization_accounts: AWS accounts to manage connections for.
+        :type organization_accounts: list
+        :param prod_env_name: The name of the prod dynatrace environment.
+        :type prod_env_name: str
+        :param prod_token: The token to use to connect to prod dynatrace.
+        :type prod_token: str
+        :param non_prod_env_name: The name of the non prod dynatrace environment.
+        :type non_prod_env_name: str
+        :param non_prod_token: The token to use to connect to non prod dynatrace.
+        :type non_prod_token: str
+        :param dynatrace_iam_role:The IAM role that Dynatrace will use as part of its connection.
+        :type dynatrace_iam_role: str
+        """
                 
-        
         self.organization_accounts = organization_accounts
         self.prod_env_name = prod_env_name
         self.prod_token = prod_token
@@ -18,6 +32,10 @@ class DynatraceUtil():
         self.dynatrace_iam_role = dynatrace_iam_role
         
     def configure_connections(self):
+        """
+        Create the Dynatrace connections if the don't exist and configure the associated
+        managed services.
+        """
         
         prod_connection_names = self.get_existing_credential_names(
             env=self.prod_env_name,
@@ -48,7 +66,17 @@ class DynatraceUtil():
                             token=self.non_prod_token,
                             account=account)  
     
-    def get_existing_credential_names(self, env: str, token: str): 
+    def get_existing_credential_names(self, env: str, token: str) -> list: 
+        """
+        Get the names of the existing connections from Dynatrace.  
+
+        :param env: The Dynatrace environment name.
+        :type env: str
+        :param token: The token to use for Authentication.
+        :type token: str
+        :return: The names of the existing connections.
+        :rtype: list
+        """
         url = f'https://{env}.live.dynatrace.com/api/config/v1/aws/credentials'
             
         Headers = {
@@ -64,13 +92,33 @@ class DynatraceUtil():
         
         return credentials
     
-    def check_if_connection_exists(self, account: dict, connection_names: list):
+    def check_if_connection_exists(self, account: dict, connection_names: list) -> bool:
+        """
+        Check if a connection to dynatrace already exists for an AWS account.
+
+        :param account: The AWS account information
+        :type account: dict
+        :param connection_names: Existing connection names.
+        :type connection_names: list
+        :return: Indicates if the connection exist or not.
+        :rtype: bool
+        """
         if account['Name'] in connection_names:
             return True
         
         return False
 
-    def create_new_credential(self, env: str, token: str, account: dict):
+    def create_new_credential(self, env: str, token: str, account: dict) -> None:
+        """
+        Create a new Dynatrace connection. 
+
+        :param env: The dynatrace environment name.
+        :type env: str
+        :param token: The token to use for authentication.
+        :type token: str
+        :param account: The AWS account information
+        :type account: dict
+        """
         url = f'https://{env}.live.dynatrace.com/api/config/v1/aws/credentials'
             
         Headers = {

--- a/python/lib/dynatrace_util.py
+++ b/python/lib/dynatrace_util.py
@@ -1,4 +1,94 @@
+import requests
+
 class DynatraceUtil():
     
-    def __init__(self, organization_accounts: list):
+    def __init__(self, organization_accounts: list, 
+                 prod_env_name: str,
+                 prod_token: str,
+                 non_prod_env_name: str, 
+                 non_prod_token: str,
+                 dynatrace_iam_role: str):
+                
+        
         self.organization_accounts = organization_accounts
+        self.prod_env_name = prod_env_name
+        self.prod_token = prod_token
+        self.non_prod_env_name = non_prod_env_name
+        self.non_prod_token = non_prod_token
+        self.dynatrace_iam_role = dynatrace_iam_role
+        
+    def configure_connections(self):
+        
+        prod_connection_names = self.get_existing_credential_names(
+            env=self.prod_env_name,
+            token=self.prod_token
+        )
+        
+        non_prod_connection_names = self.get_existing_credential_names(
+            env=self.non_prod_env_name,
+            token=self.non_prod_token
+        )
+        
+        for account in self.organization_accounts:
+            if 'prod' in account['Name']:
+                if not self.check_if_connection_exists(
+                    account=account,
+                    connection_names=prod_connection_names):
+                        self.create_new_credential(
+                            env=self.prod_env_name,
+                            token=self.prod_token,
+                            account=account)
+                    
+            else:
+                if not self.check_if_connection_exists(
+                    account=account,
+                    connection_names=non_prod_connection_names):
+                        self.create_new_credential(
+                            env=self.non_prod_env_name,
+                            token=self.non_prod_token,
+                            account=account)  
+    
+    def get_existing_credential_names(self, env: str, token: str): 
+        url = f'https://{env}.live.dynatrace.com/api/config/v1/aws/credentials'
+            
+        Headers = {
+            "accept" : "application/json; charset=utf-8",
+            "Authorization": f"Api-Token {token}"
+                  }
+        response = requests.get(url, headers=Headers)
+        
+        credentials = []
+        
+        for credential in response:
+            credentials.append(credential['name'])
+        
+        return credentials
+    
+    def check_if_connection_exists(self, account: dict, connection_names: list):
+        if account['Name'] in connection_names:
+            return True
+        
+        return False
+
+    def create_new_credential(self, env: str, token: str, account: dict):
+        url = f'https://{env}.live.dynatrace.com/api/config/v1/aws/credentials'
+            
+        Headers = {
+            "accept" : "application/json; charset=utf-8",
+            "Authorization": f"Api-Token {token}"
+                  }
+        body = {
+            'label': account['Name'],
+            'partitionType': 'AWS_DEFAULT',
+            'authenticationData': {
+                'type': 'role',
+                'roleBasedAuthentication': {
+                    'iamRole': self.dynatrace_iam_role,
+                    'accountId': account['Id']
+                },
+                'taggedOnly': False,
+                'tagsToMonitor': []
+            }
+        }
+        requests.post(url, headers=Headers, body=body)
+    

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,8 +1,12 @@
 boto3==1.28.2
 botocore==1.31.2
+certifi==2023.5.7
+charset-normalizer==3.2.0
 coverage==7.2.7
+idna==3.4
 jmespath==1.0.1
 python-dateutil==2.8.2
+requests==2.31.0
 s3transfer==0.6.1
 six==1.16.0
 urllib3==1.26.16

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,8 @@
+boto3==1.28.2
+botocore==1.31.2
+coverage==7.2.7
+jmespath==1.0.1
+python-dateutil==2.8.2
+s3transfer==0.6.1
+six==1.16.0
+urllib3==1.26.16

--- a/python/tests/test_control_tower_util.py
+++ b/python/tests/test_control_tower_util.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest import mock
-from unittest.mock import MagicMock, Mock, _Call
+from unittest.mock import MagicMock, Mock
 from lib import ControlTowerUtil, Client
 
 

--- a/python/tests/test_control_tower_util.py
+++ b/python/tests/test_control_tower_util.py
@@ -1,0 +1,272 @@
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock, Mock, _Call
+from lib import ControlTowerUtil, Client
+
+
+class TestControlTowerdUtil(unittest.TestCase):
+    
+    def setUp(self):
+        self.client = Client()
+        self.ct = ControlTowerUtil(client=self.client)
+    
+    def test_set_limit_to_account_numbers(self):
+        self.assertIsNone(self.ct.limit_to_account_numbers)
+        self.ct.set_limit_to_account_numbers('123,456')
+        self.assertEqual(self.ct.limit_to_account_numbers[0], '123')
+        self.assertEqual(self.ct.limit_to_account_numbers[1], '456')
+    
+    def test_append_accounts(self):
+        self.ct.append_accounts(['ab123', '3456'])
+        self.ct.append_accounts(['789'])
+        self.assertEqual(self.ct.accounts[0],'ab123')
+        self.assertEqual(self.ct.accounts[1],'3456')
+        self.assertEqual(self.ct.accounts[2],'789')
+    
+    def test_append_accounts_limited_accounts(self):
+        self.ct.set_limit_to_account_numbers('123,456')
+        self.ct.append_accounts([{'Id': '123'}, {'Id': '4567'}])
+        self.ct.append_accounts([{'Id': '789'}])
+        self.assertEqual(len(self.ct.accounts), 1)
+        self.assertEqual(self.ct.accounts[0], {'Id': '123'})
+    
+    def test_list_accounts_under_ou_no_child_ous_no_ou_token_no_accounts_token(self):
+        org_client = self.client.client('organizations')
+        
+        ou_return_dict = {
+            'OrganizationalUnits': [],
+            'ResponseMetadata': {}
+        }
+        
+        org_client.list_organizational_units_for_parent = MagicMock(return_value=ou_return_dict)
+        
+        
+        accounts_return_dict = {
+            'Accounts': [
+                {'Id': '111222333444'},
+                {'Id': '111122223333'}
+            ],
+            'ResponseMetadata': {}
+        }
+        org_client.list_accounts_for_parent =  MagicMock(return_value=accounts_return_dict)
+        
+        
+        self.ct.list_accounts_under_ou(parent_id='ou-abcd-a12bcdef')
+        self.assertEqual(self.ct.accounts[0], {'Id': '111222333444'})
+        self.assertEqual(self.ct.accounts[1], {'Id': '111122223333'})
+        
+    
+    def test_list_accounts_under_ou_no_child_ous_no_ou_token_with_accounts_token(self):
+        org_client = self.client.client('organizations')
+        
+        ou_return_dict = {
+            'OrganizationalUnits': [],
+            'ResponseMetadata': {}
+        }
+        
+        org_client.list_organizational_units_for_parent = MagicMock(return_value=ou_return_dict)
+        
+        accounts_return_dict_1 = {
+            'Accounts': [
+                {'Id': '111222333444'},
+                {'Id': '111122223333'}
+            ],
+            'NextToken': 'ab-123',
+            'ResponseMetadaters': {}
+        }
+        
+        accounts_return_dict_2 = {
+            'Accounts': [
+                {'Id': '111222333445'},
+                {'Id': '111122223336'}
+            ],
+            'ResponseMetadata': {}
+        }
+
+        org_client.list_accounts_for_parent =  Mock(side_effect=[accounts_return_dict_1, accounts_return_dict_2])
+        
+        self.ct.list_accounts_under_ou(parent_id='ou-abcd-a12bcdef')
+        self.assertEqual(len(self.ct.accounts), 4)
+        self.assertEqual(self.ct.accounts[0], {'Id': '111222333444'})
+        self.assertEqual(self.ct.accounts[1], {'Id': '111122223333'})
+        self.assertEqual(self.ct.accounts[2], {'Id': '111222333445'})
+        self.assertEqual(self.ct.accounts[3], {'Id': '111122223336'})
+        org_client.list_organizational_units_for_parent.assert_called_once
+        self.assertEqual(org_client.list_accounts_for_parent.call_count, 2)
+        
+        
+    def test_list_accounts_under_ou_with_child_ous_no_ou_token_with_accounts_token(self):
+        org_client = self.client.client('organizations')
+        
+        ou_return_dict_1 = {
+            'OrganizationalUnits': [
+                {
+                    'Id': '789-child'
+                }],
+            'ResponseMetadata': {}
+        }
+        
+        ou_return_dict_2 = {
+            'OrganizationalUnits': [],
+            'ResponseMetadata': {}
+        }
+        
+        org_client.list_organizational_units_for_parent = Mock(side_effect=[ou_return_dict_1, ou_return_dict_2])
+        
+        accounts_return_dict_1 = {
+            'Accounts': [
+                {'Id': '555666777888'}
+            ],
+            'ResponseMetadaters': {}
+        }
+        
+        accounts_return_dict_2 = {
+            'Accounts': [
+                {'Id': '111222333444'},
+                {'Id': '111122223333'}
+            ],
+            'NextToken': 'ab-123',
+            'ResponseMetadaters': {}
+        }
+        
+        accounts_return_dict_3 = {
+            'Accounts': [
+                {'Id': '111222333445'},
+                {'Id': '111122223336'}
+            ],
+            'ResponseMetadata': {}
+        }
+
+        org_client.list_accounts_for_parent =  Mock(side_effect=[accounts_return_dict_1, accounts_return_dict_2, accounts_return_dict_3])
+        
+        self.ct.list_accounts_under_ou(parent_id='ou-abcd-a12bcdef')
+        self.assertEqual(len(self.ct.accounts), 5)
+        self.assertEqual(self.ct.accounts[0], {'Id': '555666777888'})
+        self.assertEqual(self.ct.accounts[1], {'Id': '111222333444'})
+        self.assertEqual(self.ct.accounts[2], {'Id': '111122223333'})
+        self.assertEqual(self.ct.accounts[3], {'Id': '111222333445'})
+        self.assertEqual(self.ct.accounts[4], {'Id': '111122223336'})
+        self.assertEqual(org_client.list_organizational_units_for_parent.call_count, 2)
+        self.assertEqual(org_client.list_accounts_for_parent.call_count, 3)
+        
+    def test_list_accounts_under_ou_with_child_ous_with_ou_token_with_accounts_token(self):
+        org_client = self.client.client('organizations')
+        
+        ou_return_dict_1 = {
+            'OrganizationalUnits': [
+                {
+                    'Id': '456-child'
+                }],
+            'NextToken': 'ab-123',
+            'ResponseMetadata': {}
+        }
+        
+        ou_return_dict_2 = {
+            'OrganizationalUnits': [],
+            'ResponseMetadata': {}
+        }
+        
+        ou_return_dict_3 = {
+            'OrganizationalUnits': [
+                {
+                    'Id': '789-child'
+                }],
+            'ResponseMetadata': {},
+        }
+        
+        ou_return_dict_4 = {
+            'OrganizationalUnits': [],
+            'ResponseMetadata': {}
+        }
+        
+        
+        org_client.list_organizational_units_for_parent = Mock(side_effect=[ou_return_dict_1, ou_return_dict_2, ou_return_dict_3, ou_return_dict_4])
+        
+        accounts_return_dict_0 = {
+            'Accounts': [
+                {'Id': '999999999999'}
+            ],
+            'ResponseMetadaters': {}
+        }
+        
+        accounts_return_dict_1 = {
+            'Accounts': [
+                {'Id': '555666777888'}
+            ],
+            'ResponseMetadaters': {}
+        }
+        
+        accounts_return_dict_2 = {
+            'Accounts': [
+                {'Id': '111222333444'},
+                {'Id': '111122223333'}
+            ],
+            'NextToken': 'ab-123',
+            'ResponseMetadaters': {}
+        }
+        
+        accounts_return_dict_3 = {
+            'Accounts': [
+                {'Id': '111222333445'},
+                {'Id': '111122223336'}
+            ],
+            'ResponseMetadata': {}
+        }
+
+        org_client.list_accounts_for_parent =  Mock(side_effect=[accounts_return_dict_0, accounts_return_dict_1, accounts_return_dict_2, accounts_return_dict_3])
+        
+        self.ct.list_accounts_under_ou(parent_id='ou-abcd-a12bcdef')
+        self.assertEqual(len(self.ct.accounts), 6)
+        self.assertEqual(self.ct.accounts[0], {'Id': '999999999999'})
+        self.assertEqual(self.ct.accounts[1], {'Id': '555666777888'})
+        self.assertEqual(self.ct.accounts[2], {'Id': '111222333444'})
+        self.assertEqual(self.ct.accounts[3], {'Id': '111122223333'})
+        self.assertEqual(self.ct.accounts[4], {'Id': '111222333445'})
+        self.assertEqual(self.ct.accounts[5], {'Id': '111122223336'})
+        self.assertEqual(org_client.list_organizational_units_for_parent.call_count, 4)
+        self.assertEqual(org_client.list_accounts_for_parent.call_count, 4)
+        
+    def test_list_all_accounts_for_ou_under_root_no_token(self):
+        org_client = self.client.client('organizations')
+        
+        org_client.list_roots =  Mock(return_value={
+            'Roots': [
+                {'Id': 'x-1234'}
+            ]
+        })
+        
+        ou_return_dict_1 = {
+            'OrganizationalUnits': [
+                {
+                    'Name': 'Workload',
+                    'Id': 'hjjhs-kjbhshjkhj'
+                }
+            ],
+            'ResponseMetadata': {}
+        }
+        
+        ou_return_dict_2 = {
+            'OrganizationalUnits': [],
+            'ResponseMetadata': {}
+        }
+        
+        org_client.list_organizational_units_for_parent = Mock(side_effect=[ou_return_dict_1, ou_return_dict_2])
+        
+        
+        accounts_return_dict = {
+            'Accounts': [
+                {'Id': '111222333444'},
+                {'Id': '111122223333'}
+            ],
+            'ResponseMetadata': {}
+        }
+        org_client.list_accounts_for_parent =  MagicMock(return_value=accounts_return_dict)
+        
+        self.ct.list_all_accounts_for_ou_under_root(ou_name='Workload', account_numbers=None, apply_to_all=True)
+        org_client.list_roots.assert_called_once
+        
+        self.assertEqual(self.ct.accounts[0], {'Id': '111222333444'})
+        self.assertEqual(self.ct.accounts[1], {'Id': '111122223333'})
+    
+    if __name__ == '__main__':
+        unittest.main()

--- a/python/tests/test_dynatrace_util.py
+++ b/python/tests/test_dynatrace_util.py
@@ -1,0 +1,106 @@
+import unittest
+import requests
+from unittest.mock import MagicMock, Mock
+from lib import DynatraceUtil
+
+class TestControlTowerdUtil(unittest.TestCase):
+    
+    def setUp(self):
+        self.dt = DynatraceUtil(
+            organization_accounts=[
+                {
+                    'Name': 'conn',
+                    'Id': '123',
+                    'email': 'me@me.com'
+                },
+                {
+                    'Name': 'another-prod',
+                    'Id': '456',
+                    'email': 'you@you.org'
+                },
+                {
+                    'Name': 'prod-cred2',
+                    'id': '2'
+                }
+            ],
+            prod_env_name='prd123',
+            prod_token='dt0c01.DOIMDJDJD4CHJE5G.CZCXXETFFVX11DCW5LCCIRYAU724IND6GWREA',
+            non_prod_env_name='456non', 
+            non_prod_token='dt0c01.DOIMDJKKO9HJE5G.CZCXXETFFVX11DCW5LCCIRYA344FFGWREA',
+            dynatrace_iam_role='iam::role/hhjsdjsjhdj')
+
+    def test_check_if_connection_exists(self):
+        self.assertTrue(self.dt.check_if_connection_exists(
+            account={
+                'Name': 'conn',
+                'Id': '123'
+                }, 
+            connection_names=['conn','another']))
+        
+    def test_check_if_connection_exists_false(self):
+        self.assertFalse(self.dt.check_if_connection_exists(
+            account={
+                'Name': 'conn',
+                'Id': '123'
+                }, 
+            connection_names=['conn1','another']))
+    
+    
+    def test_get_existing_credential_names(self):
+        
+        requests.get = MagicMock(return_value=[
+            {
+                'name': 'cred1',
+                'id': 1 
+            },
+            {
+                'name': 'cred2',
+                'id': 55 
+            }
+        ])
+        
+        credentials = self.dt.get_existing_credential_names(env='', token='')
+        self.assertEqual(credentials[0], 'cred1')
+        self.assertEqual(credentials[1], 'cred2')
+        
+    def test_create_new_credential(self):
+        
+        requests.post = MagicMock(return_value='')
+        self.dt.create_new_credential(
+            env='prod',
+            token='hdhdjkfhkh',
+            account={
+                'Name': 'conn',
+                'Id': '123',
+                'email': 'me@me.com'
+            })
+        requests.post.assert_called_once
+        
+    def test_configure_connections(self):
+        
+        get_responses = [
+            [
+                {
+                    'name': 'prod-cred1',
+                    'id': 1 
+                },
+                {
+                    'name': 'prod-cred2',
+                    'id': 2 
+                }
+            ],
+            [
+                {
+                    'name': 'non-cred1',
+                    'id': 3
+                }
+            ]
+        ]
+        
+        requests.get = Mock(side_effect=get_responses)
+        requests.post = Mock(side_effect=['','',''])
+        
+        self.dt.configure_connections()
+        
+        self.assertEqual(requests.get.call_count, 2)
+        self.assertEqual(requests.post.call_count, 2)


### PR DESCRIPTION
Python application when a role with the correct permission is assumed when run will get all of the accounts under an ou within a AWS organisation.

Missing Documentation as it is still a work in progress. More functionality to come and what is there may change.

PLAT-1916 is now also included in this PR. This change creates Dynatrace connections if they do not exist

Test coverage is currently at 86%

